### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-publish-ansible-psrp-krb5-sc.yaml
+++ b/.github/workflows/build-publish-ansible-psrp-krb5-sc.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Publish to Docker Repository
         env:
           _IMAGE_LONG_VERSION: ${{ env._ANSIBLE_VERSION }}-${{ env._IMAGE_VARIANT }}-${{ env._BASE_IMAGE }}${{ env._BASE_IMAGE_VERSION }}
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKERHUB_REPO }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-publish-ansible-psrp-krb5.yaml
+++ b/.github/workflows/build-publish-ansible-psrp-krb5.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish to Docker Repository
         env:
           _IMAGE_LONG_VERSION: ${{ env._ANSIBLE_VERSION }}-${{ env._IMAGE_VARIANT }}-${{ env._BASE_IMAGE }}${{ env._BASE_IMAGE_VERSION }}
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKERHUB_REPO }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-publish-ansible-ssh-krb5.yaml
+++ b/.github/workflows/build-publish-ansible-ssh-krb5.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Publish to Docker Repository
         env:
           _IMAGE_LONG_VERSION: ${{ env._ANSIBLE_VERSION }}-${{ env._IMAGE_VARIANT }}-${{ env._BASE_IMAGE }}${{ env._BASE_IMAGE_VERSION }}
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           context: dockerfiles/ansible-ssh-krb5
           buildargs: BASE_IMAGE_VERSION=${{ env._BASE_IMAGE_VERSION }}, ANSIBLE_VERSION=${{ env._ANSIBLE_VERSION }}, VCS_URL=${{ env._GH_BASE_URI }}${{ env.GITHUB_REPOSITORY }}, VCS_REF=${{ env.GITHUB_SHA }}, IMAGE_LONG_VERSION=${{ env._IMAGE_LONG_VERSION }}

--- a/.github/workflows/build-publish-ansible-winrm-krb5-sc.yaml
+++ b/.github/workflows/build-publish-ansible-winrm-krb5-sc.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Publish to Docker Repository
         env:
           _IMAGE_LONG_VERSION: ${{ env._ANSIBLE_VERSION }}-${{ env._IMAGE_VARIANT }}-${{ env._BASE_IMAGE }}${{ env._BASE_IMAGE_VERSION }}
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           context: dockerfiles/ansible-winrm-krb5-sc
           buildargs: BASE_IMAGE_VERSION=${{ env._BASE_IMAGE_VERSION }}, ANSIBLE_VERSION=${{ env._ANSIBLE_VERSION }}, VCS_URL=${{ env._GH_BASE_URI }}${{ env.GITHUB_REPOSITORY }}, VCS_REF=${{ env.GITHUB_SHA }}, IMAGE_LONG_VERSION=${{ env._IMAGE_LONG_VERSION }}

--- a/.github/workflows/build-publish-ansible-winrm-krb5.yaml
+++ b/.github/workflows/build-publish-ansible-winrm-krb5.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Publish to Docker Repository
         env:
           _IMAGE_LONG_VERSION: ${{ env._ANSIBLE_VERSION }}-${{ env._IMAGE_VARIANT }}-${{ env._BASE_IMAGE }}${{ env._BASE_IMAGE_VERSION }}
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           context: dockerfiles/ansible-winrm-krb5
           buildargs: BASE_IMAGE_VERSION=${{ env._BASE_IMAGE_VERSION }}, ANSIBLE_VERSION=${{ env._ANSIBLE_VERSION }}, VCS_URL=${{ env._GH_BASE_URI }}${{ env.GITHUB_REPOSITORY }}, VCS_REF=${{ env.GITHUB_SHA }}, IMAGE_LONG_VERSION=${{ env._IMAGE_LONG_VERSION }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore